### PR TITLE
add --module-syntax configure option, make it work for --module-syntax=Lua, properly handle module header line

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -67,7 +67,7 @@ from easybuild.tools.filetools import extract_file, mkdir, read_file, rmtree2
 from easybuild.tools.filetools import write_file, compute_checksum, verify_checksum
 from easybuild.tools.run import run_cmd
 from easybuild.tools.jenkins import write_to_xml
-from easybuild.tools.module_generator import ModuleGeneratorLua
+from easybuild.tools.module_generator import module_generator
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.modules import ROOT_ENV_VAR_NAME_PREFIX, VERSION_ENV_VAR_NAME_PREFIX, DEVEL_ENV_VAR_NAME_PREFIX
 from easybuild.tools.modules import get_software_root, modules_tool
@@ -132,7 +132,7 @@ class EasyBlock(object):
         # modules interface with default MODULEPATH
         self.modules_tool = modules_tool()
         # module generator
-        self.module_generator = ModuleGeneratorLua(self, fake=True)
+        self.module_generator = module_generator()
 
         # modules footer
         self.modules_footer = None
@@ -745,7 +745,6 @@ class EasyBlock(object):
         # load fake module
         fake_mod_data = self.load_fake_module(purge=True)
 
-        mod_gen = ModuleGeneratorLua(self)
         header = "#%Module\n"
 
         env_txt = ""
@@ -753,7 +752,7 @@ class EasyBlock(object):
             # check if non-empty string
             # TODO: add unset for empty vars?
             if val.strip():
-                env_txt += mod_gen.set_environment(key, val)
+                env_txt += self.module_generator.set_environment(key, val)
 
         load_txt = ""
         # capture all the EBDEVEL vars
@@ -765,7 +764,7 @@ class EasyBlock(object):
                     path = os.environ[key]
                     if os.path.isfile(path):
                         mod_name = path.rsplit(os.path.sep, 1)[-1]
-                        load_txt += mod_gen.load_module(mod_name)
+                        load_txt += self.module_generator.load_module(mod_name)
             elif key.startswith('SOFTDEVEL'):
                 self.log.nosupport("Environment variable SOFTDEVEL* being relied on", '2.0')
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -132,7 +132,7 @@ class EasyBlock(object):
         # modules interface with default MODULEPATH
         self.modules_tool = modules_tool()
         # module generator
-        self.module_generator = module_generator()
+        self.module_generator = module_generator(self, fake=True)
 
         # modules footer
         self.modules_footer = None

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -745,7 +745,7 @@ class EasyBlock(object):
         # load fake module
         fake_mod_data = self.load_fake_module(purge=True)
 
-        header = "#%Module\n"
+        header = self.module_generator.module_header()
 
         env_txt = ""
         for (key, val) in env.get_changes().items():

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -54,6 +54,7 @@ _log = fancylogger.getLogger('config', fname=False)
 
 DEFAULT_LOGFILE_FORMAT = ("easybuild", "easybuild-%(name)s-%(version)s-%(date)s.%(time)s.log")
 DEFAULT_MNS = 'EasyBuildMNS'
+DEFAULT_MODULE_SYNTAX = 'Tcl'
 DEFAULT_MODULES_TOOL = 'EnvironmentModulesC'
 DEFAULT_PATH_SUBDIRS = {
     'buildpath': 'build',

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -177,20 +177,21 @@ class ConfigurationVariables(FrozenDictKnownKeys):
 
     # list of known/required keys
     REQUIRED = [
-        'config',
-        'prefix',
         'buildpath',
+        'config',
         'installpath',
-        'sourcepath',
+        'logfile_format',
+        'moduleclasses',
+        'module_naming_scheme',
+        'module_syntax',
+        'modules_tool',
+        'prefix',
         'repository',
         'repositorypath',
-        'logfile_format',
-        'tmp_logdir',
-        'moduleclasses',
+        'sourcepath',
         'subdir_modules',
         'subdir_software',
-        'modules_tool',
-        'module_naming_scheme',
+        'tmp_logdir',
     ]
     KNOWN_KEYS = REQUIRED  # KNOWN_KEYS must be defined for FrozenDictKnownKeys functionality
 

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -350,9 +350,16 @@ def get_modules_tool():
 
 def get_module_naming_scheme():
     """
-    Return module naming scheme (EasyBuild, ...)
+    Return module naming scheme (EasyBuildMNS, HierarchicalMNS, ...)
     """
     return ConfigurationVariables()['module_naming_scheme']
+
+
+def get_module_syntax():
+    """
+    Return module syntax (Lua, Tcl)
+    """
+    return ConfigurationVariables()['module_syntax']
 
 
 def log_file_format(return_directory=False):

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -40,7 +40,7 @@ from vsc.utils.missing import get_subclasses
 
 from easybuild.framework.easyconfig.easyconfig import ActiveMNS
 from easybuild.tools import config
-from easybuild.tools.config import build_option
+from easybuild.tools.config import build_option, get_module_syntax
 from easybuild.tools.filetools import mkdir
 from easybuild.tools.utilities import quote_str
 
@@ -412,7 +412,7 @@ class ModuleGeneratorLua(ModuleGenerator):
         return 'setalias(%s,"%s")\n' % (key, quote_str(value))
 
 
-def avail_module_syntaxes():
+def avail_module_generators():
     """
     Return all known module syntaxes.
     """
@@ -426,3 +426,12 @@ def avail_module_syntaxes():
             tup = (MODULE_GENERATOR_CLASS_PREFIX, class_name)
             _log.error("Invalid name for ModuleGenerator subclass, should start with %s: %s" % tup)
     return class_dict
+
+
+def module_generator():
+    """
+    Return interface to modules tool (environment modules (C, Tcl), or Lmod)
+    """
+    module_syntax = get_module_syntax()
+    module_generator_class = avail_module_generators().get(module_syntax)
+    return module_generator_class()

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -36,13 +36,16 @@ import os
 import re
 import tempfile
 from vsc.utils import fancylogger
+from vsc.utils.missing import get_subclasses
 
 from easybuild.framework.easyconfig.easyconfig import ActiveMNS
 from easybuild.tools import config
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import mkdir
-from easybuild.tools.module_naming_scheme.utilities import det_hidden_modname
 from easybuild.tools.utilities import quote_str
+
+
+MODULE_GENERATOR_CLASS_PREFIX = 'ModuleGenerator'
 
 
 _log = fancylogger.getLogger('module_generator', fname=False)
@@ -407,3 +410,19 @@ class ModuleGeneratorLua(ModuleGenerator):
         """
     # quotes are needed, to ensure smooth working of EBDEVEL* modulefiles
         return 'setalias(%s,"%s")\n' % (key, quote_str(value))
+
+
+def avail_module_syntaxes():
+    """
+    Return all known module syntaxes.
+    """
+    class_dict = {}
+    for klass in get_subclasses(ModuleGenerator):
+        class_name = klass.__name__
+        if class_name.startswith(MODULE_GENERATOR_CLASS_PREFIX):
+            syntax = class_name[len(MODULE_GENERATOR_CLASS_PREFIX):]
+            class_dict.update({syntax: klass})
+        else:
+            tup = (MODULE_GENERATOR_CLASS_PREFIX, class_name)
+            _log.error("Invalid name for ModuleGenerator subclass, should start with %s: %s" % tup)
+    return class_dict

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -116,12 +116,19 @@ class ModuleGenerator(object):
         else:
             self.module_path = config.install_path('mod')
 
+    def module_header(self):
+        """Return module header string."""
+        raise NotImplementedError
+
 
 class ModuleGeneratorTcl(ModuleGenerator):
     """
     Class for generating Tcl module files.
     """
 
+    def module_header(self):
+        """Return module header string."""
+        return "#%Module\n"
 
     def get_description(self, conflict=True):
         """
@@ -130,7 +137,6 @@ class ModuleGeneratorTcl(ModuleGenerator):
         description = "%s - Homepage: %s" % (self.app.cfg['description'], self.app.cfg['homepage'])
 
         lines = [
-            "#%%Module",  # double % to escape string formatting!
             "",
             "proc ModulesHelp { } {",
             "    puts stderr {   %(description)s",
@@ -161,7 +167,8 @@ class ModuleGeneratorTcl(ModuleGenerator):
             # - 'conflict Compiler/GCC/4.8.2/OpenMPI' for 'Compiler/GCC/4.8.2/OpenMPI/1.6.4'
             lines.append("conflict %s\n" % os.path.dirname(self.app.short_mod_name))
 
-        txt = '\n'.join(lines) % {
+        txt = self.module_header()
+        txt += '\n'.join(lines) % {
             'name': self.app.name,
             'version': self.app.version,
             'description': description,
@@ -270,6 +277,10 @@ class ModuleGeneratorLua(ModuleGenerator):
     """
     Class for generating Lua module files.
     """
+
+    def module_header(self):
+        """Return module header string."""
+        return ''
 
     def get_description(self, conflict=True):
         """

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -60,7 +60,6 @@ class ModuleGenerator(object):
     CHARS_TO_ESCAPE = ["$"]
 
     def __init__(self, application, fake=False):
-        self.fake = fake
         self.app = application
         self.fake = fake
         self.tmpdir = None
@@ -428,10 +427,10 @@ def avail_module_generators():
     return class_dict
 
 
-def module_generator():
+def module_generator(app, fake=False):
     """
     Return interface to modules tool (environment modules (C, Tcl), or Lmod)
     """
     module_syntax = get_module_syntax()
     module_generator_class = avail_module_generators().get(module_syntax)
-    return module_generator_class()
+    return module_generator_class(app, fake=fake)

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -835,6 +835,7 @@ class Lmod(ModulesTool):
 
     def update(self):
         """Update after new modules were added."""
+        return
         spider_cmd = os.path.join(os.path.dirname(self.cmd), 'spider')
         cmd = [spider_cmd, '-o', 'moduleT', os.environ['MODULEPATH']]
         self.log.debug("Running command '%s'..." % ' '.join(cmd))

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -55,7 +55,7 @@ from easybuild.tools.config import mk_full_default_path
 from easybuild.tools.docs import FORMAT_RST, FORMAT_TXT, avail_easyconfig_params
 from easybuild.tools.github import HAVE_GITHUB_API, HAVE_KEYRING, fetch_github_token
 from easybuild.tools.modules import avail_modules_tools
-from easybuild.tools.module_generator import avail_module_syntaxes
+from easybuild.tools.module_generator import avail_module_generators
 from easybuild.tools.module_naming_scheme import GENERAL_CLASS
 from easybuild.tools.module_naming_scheme.utilities import avail_module_naming_schemes
 from easybuild.tools.ordereddict import OrderedDict
@@ -228,7 +228,7 @@ class EasyBuildOptions(GeneralOption):
             'module-naming-scheme': ("Module naming scheme",
                                      'choice', 'store', DEFAULT_MNS, sorted(avail_module_naming_schemes().keys())),
             'module-syntax': ("Syntax to be used for module files", 'choice', 'store', DEFAULT_MODULE_SYNTAX,
-                              sorted(avail_module_syntaxes().keys())),
+                              sorted(avail_module_generators().keys())),
             'moduleclasses': (("Extend supported module classes "
                                "(For more info on the default classes, use --show-default-moduleclasses)"),
                                None, 'extend', [x[0] for x in DEFAULT_MODULECLASSES]),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -48,13 +48,14 @@ from easybuild.framework.easyconfig.templates import template_documentation
 from easybuild.framework.easyconfig.tools import get_paths_for
 from easybuild.framework.extension import Extension
 from easybuild.tools import build_log, config, run  # @UnusedImport make sure config is always initialized!
-from easybuild.tools.config import DEFAULT_LOGFILE_FORMAT, DEFAULT_MNS, DEFAULT_MODULES_TOOL, DEFAULT_MODULECLASSES
-from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, DEFAULT_PREFIX, DEFAULT_REPOSITORY
+from easybuild.tools.config import DEFAULT_LOGFILE_FORMAT, DEFAULT_MNS, DEFAULT_MODULE_SYNTAX, DEFAULT_MODULES_TOOL
+from easybuild.tools.config import DEFAULT_MODULECLASSES, DEFAULT_PATH_SUBDIRS, DEFAULT_PREFIX, DEFAULT_REPOSITORY
 from easybuild.tools.config import get_pretend_installpath
 from easybuild.tools.config import mk_full_default_path
 from easybuild.tools.docs import FORMAT_RST, FORMAT_TXT, avail_easyconfig_params
 from easybuild.tools.github import HAVE_GITHUB_API, HAVE_KEYRING, fetch_github_token
 from easybuild.tools.modules import avail_modules_tools
+from easybuild.tools.module_generator import avail_module_syntaxes
 from easybuild.tools.module_naming_scheme import GENERAL_CLASS
 from easybuild.tools.module_naming_scheme.utilities import avail_module_naming_schemes
 from easybuild.tools.ordereddict import OrderedDict
@@ -226,6 +227,8 @@ class EasyBuildOptions(GeneralOption):
                                'strtuple', 'store', DEFAULT_LOGFILE_FORMAT[:], {'metavar': 'DIR,FORMAT'}),
             'module-naming-scheme': ("Module naming scheme",
                                      'choice', 'store', DEFAULT_MNS, sorted(avail_module_naming_schemes().keys())),
+            'module-syntax': ("Syntax to be used for module files", 'choice', 'store', DEFAULT_MODULE_SYNTAX,
+                              sorted(avail_module_syntaxes().keys())),
             'moduleclasses': (("Extend supported module classes "
                                "(For more info on the default classes, use --show-default-moduleclasses)"),
                                None, 'extend', [x[0] for x in DEFAULT_MODULECLASSES]),


### PR DESCRIPTION
currently (still) broken: generating Tcl module files