### PR TITLE
keep module load regex in module_generator.py + fixes for other small remarks

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -53,6 +53,8 @@ from easybuild.framework.easyconfig.tools import get_paths_for, parse_easyconfig
 from easybuild.framework.easyconfig.tweak import obtain_ec_for, tweak
 from easybuild.tools.config import get_repository, get_repositorypath, set_tmpdir
 from easybuild.tools.filetools import cleanup, write_file
+from easybuild.tools.module_generator import module_load_regex
+from easybuild.tools.modules import modules_tool
 from easybuild.tools.options import process_software_build_specs
 from easybuild.tools.robot import det_robot_path, dry_run, resolve_dependencies, search_easyconfigs
 from easybuild.tools.parallelbuild import submit_jobs
@@ -207,6 +209,10 @@ def main(testing_data=(None, None, None)):
     # initialise the EasyBuild configuration & build options
     config.init(options, config_options_dict)
     config.init_build_options(build_options=build_options, cmdline_options=options)
+
+    # inject function to determine regex for 'load' statements in modules into ModulesTool instance
+    # we need to resort to this trickery to avoid cyclic imports (while retaining top-level imports)
+    modules_tool().set_load_regex_function(module_load_regex)
 
     # update session state
     eb_config = eb_go.generate_cmd_line(add_default=True)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -55,7 +55,7 @@ from easybuild.tools.config import mk_full_default_path
 from easybuild.tools.docs import FORMAT_RST, FORMAT_TXT, avail_easyconfig_params
 from easybuild.tools.github import HAVE_GITHUB_API, HAVE_KEYRING, fetch_github_token
 from easybuild.tools.modules import avail_modules_tools
-from easybuild.tools.module_generator import LUA_SYNTAX, avail_module_generators
+from easybuild.tools.module_generator import ModuleGeneratorLua, avail_module_generators
 from easybuild.tools.module_naming_scheme import GENERAL_CLASS
 from easybuild.tools.module_naming_scheme.utilities import avail_module_naming_schemes
 from easybuild.tools.modules import Lmod
@@ -399,7 +399,7 @@ class EasyBuildOptions(GeneralOption):
             if not HAVE_GITHUB_API:
                 self.log.error("Required support for using GitHub API is not available (see warnings).")
 
-        if self.options.module_syntax == LUA_SYNTAX and self.options.modules_tool != Lmod.__name__:
+        if self.options.module_syntax == ModuleGeneratorLua.SYNTAX and self.options.modules_tool != Lmod.__name__:
             self.log.error("Generating Lua module files requires Lmod as modules tool.")
 
         # make sure a GitHub token is available when it's required

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -39,6 +39,7 @@ import easybuild.tools.modules as modules
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, ActiveMNS
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import write_file
+from easybuild.tools.module_generator import module_load_regex
 from easybuild.tools.toolchain.utilities import search_toolchain
 from test.framework.utilities import find_full_path
 
@@ -50,7 +51,9 @@ class ToolchainTest(EnhancedTestCase):
         super(ToolchainTest, self).setUp()
 
         # start with a clean slate
-        modules.modules_tool().purge()
+        modtool = modules.modules_tool()
+        modtool.purge()
+        modtool.set_load_regex_function(module_load_regex)
 
         # make sure path with modules for testing is added to MODULEPATH
         self.orig_modpath = os.environ.get('MODULEPATH', '')


### PR DESCRIPTION
fix for the regex/conflict issue we discussed, for https://github.com/hpcugent/easybuild-framework/pull/1060

it's a bit dirty, but I can't find a better way to avoid a cyclic import (other than doing a local import, which I really want to stay away from)