### PR TITLE
fix nasty hack to inject module_load_regex function into ModulesTool instance

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1641,7 +1641,7 @@ class EasyBlock(object):
         """
         self.module_generator.set_fake(fake)
 
-        mod_symlink_paths = ActiveMNS().det_module_symlink_paths(self.app.cfg)
+        mod_symlink_paths = ActiveMNS().det_module_symlink_paths(self.cfg)
         modpath = self.module_generator.prepare(mod_symlink_paths)
 
         txt = ''

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1640,7 +1640,9 @@ class EasyBlock(object):
         Generate a module file.
         """
         self.module_generator.set_fake(fake)
-        modpath = self.module_generator.prepare()
+
+        mod_symlink_paths = ActiveMNS().det_module_symlink_paths(self.app.cfg)
+        modpath = self.module_generator.prepare(mod_symlink_paths)
 
         txt = ''
         txt += self.make_module_description()

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -53,8 +53,6 @@ from easybuild.framework.easyconfig.tools import get_paths_for, parse_easyconfig
 from easybuild.framework.easyconfig.tweak import obtain_ec_for, tweak
 from easybuild.tools.config import get_repository, get_repositorypath, set_tmpdir
 from easybuild.tools.filetools import cleanup, write_file
-from easybuild.tools.module_generator import module_load_regex
-from easybuild.tools.modules import modules_tool
 from easybuild.tools.options import process_software_build_specs
 from easybuild.tools.robot import det_robot_path, dry_run, resolve_dependencies, search_easyconfigs
 from easybuild.tools.parallelbuild import submit_jobs
@@ -209,10 +207,6 @@ def main(testing_data=(None, None, None)):
     # initialise the EasyBuild configuration & build options
     config.init(options, config_options_dict)
     config.init_build_options(build_options=build_options, cmdline_options=options)
-
-    # inject function to determine regex for 'load' statements in modules into ModulesTool instance
-    # we need to resort to this trickery to avoid cyclic imports (while retaining top-level imports)
-    modules_tool().set_load_regex_function(module_load_regex)
 
     # update session state
     eb_config = eb_go.generate_cmd_line(add_default=True)

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -40,12 +40,11 @@ import string
 import tempfile
 import time
 from vsc.utils import fancylogger
-from vsc.utils.missing import nub, FrozenDictKnownKeys
+from vsc.utils.missing import FrozenDictKnownKeys
 from vsc.utils.patterns import Singleton
 
 import easybuild.tools.build_log  # this import is required to obtain a correct (EasyBuild) logger!
 import easybuild.tools.environment as env
-from easybuild.tools.environment import read_environment as _read_environment
 from easybuild.tools.run import run_cmd
 
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -38,7 +38,6 @@ This python module implements the environment modules functionality:
 import os
 import re
 import subprocess
-import sys
 from distutils.version import StrictVersion
 from subprocess import PIPE
 from vsc.utils import fancylogger
@@ -51,7 +50,6 @@ from easybuild.tools.environment import restore_env
 from easybuild.tools.filetools import convert_name, mkdir, read_file, path_matches, which
 from easybuild.tools.module_naming_scheme import DEVEL_MODULE_SUFFIX
 from easybuild.tools.run import run_cmd
-from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME, DUMMY_TOOLCHAIN_VERSION
 from vsc.utils.missing import nub
 
 # software root/version environment variable name prefixes
@@ -175,12 +173,6 @@ class ModulesTool(object):
         self.set_and_check_version()
 
         self.det_load_regex = None
-
-    def set_load_regex_function(self, det_load_regex):
-        """
-        Set function to determine regex for 'load' statements.
-        """
-        self.det_load_regex = det_load_regex
 
     def buildstats(self):
         """Return tuple with data to be included in buildstats"""
@@ -573,30 +565,6 @@ class ModulesTool(object):
         self.log.debug("modulefile path %s: %s" % (mod_name, modfilepath))
 
         return read_file(modfilepath)
-
-    def dependencies_for(self, mod_name, depth=sys.maxint):
-        """
-        Obtain a list of dependencies for the given module, determined recursively, up to a specified depth (optionally)
-        @param depth: recursion depth (default is sys.maxint, which should be equivalent to infinite recursion depth)
-        """
-        modtxt = self.read_module_file(mod_name)
-        loadregex = self.det_load_regex(self.modulefile_path(mod_name))
-        mods = loadregex.findall(modtxt)
-
-        if depth > 0:
-            # recursively determine dependencies for these dependency modules, until depth is non-positive
-            moddeps = [self.dependencies_for(mod, depth=depth - 1) for mod in mods]
-        else:
-            # ignore any deeper dependencies
-            moddeps = []
-
-        # add dependencies of dependency modules only if they're not there yet
-        for moddepdeps in moddeps:
-            for dep in moddepdeps:
-                if not dep in mods:
-                    mods.append(dep)
-
-        return mods
 
     def modpath_extensions_for(self, mod_names):
         """

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -32,11 +32,11 @@ Creating a new toolchain should be as simple as possible.
 """
 
 import os
-import re
 from vsc.utils import fancylogger
 
 from easybuild.tools.config import build_option, install_path
 from easybuild.tools.environment import setvar
+from easybuild.tools.module_generator import dependencies_for
 from easybuild.tools.modules import get_software_root, get_software_version, modules_tool
 from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME, DUMMY_TOOLCHAIN_VERSION
 from easybuild.tools.toolchain.options import ToolchainOptions
@@ -353,7 +353,7 @@ class Toolchain(object):
 
         # determine direct toolchain dependencies
         mod_name = self.det_short_module_name()
-        self.toolchain_dep_mods = self.modules_tool.dependencies_for(mod_name, depth=0)
+        self.toolchain_dep_mods = dependencies_for(mod_name, depth=0)
         self.log.debug('prepare: list of direct toolchain dependencies: %s' % self.toolchain_dep_mods)
 
         # only retain names of toolchain elements, excluding toolchain name

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -39,7 +39,6 @@ import easybuild.tools.modules as modules
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, ActiveMNS
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import write_file
-from easybuild.tools.module_generator import module_load_regex
 from easybuild.tools.toolchain.utilities import search_toolchain
 from test.framework.utilities import find_full_path
 
@@ -51,9 +50,7 @@ class ToolchainTest(EnhancedTestCase):
         super(ToolchainTest, self).setUp()
 
         # start with a clean slate
-        modtool = modules.modules_tool()
-        modtool.purge()
-        modtool.set_load_regex_function(module_load_regex)
+        modules.modules_tool().purge()
 
         # make sure path with modules for testing is added to MODULEPATH
         self.orig_modpath = os.environ.get('MODULEPATH', '')


### PR DESCRIPTION
no more nasty hacks, the main trick was to stop importing `ActiveMNS` in `module_generator.py`...