### PR TITLE
enhance test that includes hard check for use of '$root' in module file

### DIFF
--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -309,7 +309,8 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertTrue(re.search("^#%Module", txt.split('\n')[0]))
         self.assertTrue(re.search("^conflict\s+%s$" % name, txt, re.M))
         self.assertTrue(re.search("^set\s+root\s+%s$" % eb.installdir, txt, re.M))
-        self.assertTrue(re.search('^setenv\s+EBROOT%s\s+".root"\s*$' % name.upper(), txt, re.M))
+        ebroot_regex = re.compile('^setenv\s+EBROOT%s\s+".root"\s*$' % name.upper())
+        self.assertTrue(ebroot_regex.search(txt, re.M), "%s in %s" % (ebroot_regex.pattern, txt))
         self.assertTrue(re.search('^setenv\s+EBVERSION%s\s+"%s"$' % (name.upper(), version), txt, re.M))
         for (key, val) in modextravars.items():
             regex = re.compile('^setenv\s+%s\s+"%s"$' % (key, val), re.M)


### PR DESCRIPTION
something small I had done for https://github.com/hpcugent/easybuild-framework/pull/1060

doesn't fix anything, just tries to make the failing test more clear