### PR TITLE
fix typo in easyblock.py

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -847,7 +847,7 @@ class EasyBlock(object):
         environment_name = convert_name(self.name, upper=True)
         
         if self.module_generator.SYNTAX == 'Lua':
-            txt += self.module_generator.self_environment(ROOT_ENV_VAR_NAME_PREFIX + environment_name, self.installdir)
+            txt += self.module_generator.set_environment(ROOT_ENV_VAR_NAME_PREFIX + environment_name, self.installdir)
             devel_path = os.path.join(self.installdir, log_path(), ActiveMNS().det_devel_module_filename(self.cfg))
         elif self.module_generator.SYNTAX == 'Tcl':
             txt += self.module_generator.set_environment(ROOT_ENV_VAR_NAME_PREFIX + environment_name, "$root")


### PR DESCRIPTION
some of the tests are broken with `$TEST_EASYBUILD_MODULE_SYNTAX=Tcl` and `$TEST_EASYBUILD_MODULES_TOOL=Lmod` set, I'll look into that too